### PR TITLE
Suggest manual installation of cython and numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ a Python-based simulation framework for bionic vision
 ## Installation
 
 Required packages listed in `requirements.txt`.
-Automatically install all requirements plus package `argus_shapes`:
+
+To install all of the requirements and the `argus_shapes` package:
 
 ```
     $ pip install numpy
     $ pip install cython
+    $ pip install -r requirements.txt
     $ pip install -e .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ scikit-image
 pulse2percept
 pyswarm
 xlrd
+jupyter
+notebook


### PR DESCRIPTION
Sadly, cython and numpy seem to be required before you can install anything else here. This is because the setup for this, as well as for pulse2percept assume that you have these installed before it starts running.